### PR TITLE
Refactor to provide options functions for cleaner use

### DIFF
--- a/spinner_test.go
+++ b/spinner_test.go
@@ -9,14 +9,14 @@ import (
 )
 
 // Test implementation of io.Writer; gets passed into
-// the spinner so we can test written values
-type TestWriter struct {
+// the spinner so we can test written values.
+type testWriter struct {
 	output []string
 }
 
 // Write just adds the supplied data to the output slice
-// for later inspection
-func (tw *TestWriter) Write(data []byte) (int, error) {
+// for later inspection.
+func (tw *testWriter) Write(data []byte) (int, error) {
 	tw.output = append(tw.output, string(data))
 	return len(data), nil
 }
@@ -24,11 +24,10 @@ func (tw *TestWriter) Write(data []byte) (int, error) {
 func TestSpinner(t *testing.T) {
 	expected := []string{"\r-", "\r\\", "\r|", "\r/"}
 
-	s := spinner.NewSpinner()
-	testWriter := &TestWriter{}
-	s.Writer = testWriter
+	tw := &testWriter{}
+	s := spinner.New(spinner.Writer(tw))
 
-	testSpinner(t, s, testWriter, expected)
+	testSpinner(t, s, tw, expected)
 }
 
 func TestSpinnerWithPrefix(t *testing.T) {
@@ -40,15 +39,13 @@ func TestSpinnerWithPrefix(t *testing.T) {
 		fmt.Sprintf("\r%s/", prefix),
 	}
 
-	s := spinner.NewSpinner()
-	s.Prefix = prefix
-	testWriter := &TestWriter{}
-	s.Writer = testWriter
+	tw := &testWriter{}
+	s := spinner.New(spinner.Prefix(prefix), spinner.Writer(tw))
 
-	testSpinner(t, s, testWriter, expected)
+	testSpinner(t, s, tw, expected)
 }
 
-func testSpinner(t *testing.T, s spinner.Spinner, tw *TestWriter, expected []string) {
+func testSpinner(t *testing.T, s *spinner.Spinner, tw *testWriter, expected []string) {
 	s.Start()
 	time.Sleep(350 * time.Millisecond)
 	s.Stop()


### PR DESCRIPTION
Provide options functions for cleaner API use. Callers can now invoke:
```
spinner.New(spinner.Prefix("foo"))
```

instead of:

```
s := spinner.NewSpinner()
s.Prefix("foo")
...
```
The same applies to the `io.Writer` used internally, which can be set by passing in `spinner.Writer(w)`.